### PR TITLE
Validate daemon LocalServerSocket peer UID before using connection

### DIFF
--- a/mobile/src/main/java/be/mygod/vpnhotspot/root/daemon/DaemonController.kt
+++ b/mobile/src/main/java/be/mygod/vpnhotspot/root/daemon/DaemonController.kt
@@ -160,9 +160,19 @@ object DaemonController {
                     }
                 }
                 withTimeoutOrNull(10.seconds) { serverSocket.accept() }.also {
-                    socket = it ?: throw IOException("Timed out waiting for $BINARY_NAME to connect")
-                    input = it.openReadChannel()
-                    output = it.openWriteChannel()
+                    val daemonSocket = it ?: throw IOException("Timed out waiting for $BINARY_NAME to connect")
+                    val peerUid = try {
+                        daemonSocket.getPeerCredentials().uid
+                    } catch (e: ErrnoException) {
+                        throw IOException("Failed to verify $BINARY_NAME peer credentials", e)
+                    }
+                    if (peerUid != 0) {
+                        daemonSocket.close()
+                        throw IOException("Unexpected $BINARY_NAME peer uid $peerUid")
+                    }
+                    socket = daemonSocket
+                    input = daemonSocket.openReadChannel()
+                    output = daemonSocket.openWriteChannel()
                     startReaderLocked(input!!)
                     Timber.d("Started $BINARY_NAME")
                 }


### PR DESCRIPTION
### Motivation

- Ensure the accepted LocalServerSocket connection actually originates from the privileged daemon process by verifying peer credentials before using the socket. 
- Fail early and close unexpected or unprivileged connections to prevent misuse or privilege confusion when talking to the native daemon.

### Description

- Rename the accepted socket to `daemonSocket` and retrieve its peer credentials via `daemonSocket.getPeerCredentials().uid`, wrapping `ErrnoException` in an `IOException` on failure. 
- Close the socket and throw an `IOException` when the peer UID is not `0` to enforce that the peer is root. 
- Only open read/write channels and assign `socket`, `input`, and `output` after the UID check succeeds.

### Testing

- Ran unit tests with `./gradlew test`, which completed successfully. 
- Built the app with `./gradlew assembleDebug`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a317587a08320a1e9c75f727126d5)