### PR TITLE
[codex] Authenticate daemon socket peer

### DIFF
--- a/docs/vpnhotspotd/lifecycle.md
+++ b/docs/vpnhotspotd/lifecycle.md
@@ -35,7 +35,9 @@ not open the rtnetlink connection. Once created, the runtime remains
 process-wide until daemon exit.
 
 The daemon does not listen for arbitrary clients. The app-side controller owns
-the listening socket and the daemon connects to that single controller.
+the listening socket and accepts only a peer whose Unix socket credentials have
+`uid=0`; non-root peers are closed and the controller keeps waiting within the
+startup timeout. The daemon connects to that single controller.
 
 ## Calls
 

--- a/mobile/src/main/java/be/mygod/vpnhotspot/root/daemon/DaemonController.kt
+++ b/mobile/src/main/java/be/mygod/vpnhotspot/root/daemon/DaemonController.kt
@@ -159,13 +159,34 @@ object DaemonController {
                         stderr = null
                     }
                 }
-                withTimeoutOrNull(10.seconds) { serverSocket.accept() }.also {
-                    socket = it ?: throw IOException("Timed out waiting for $BINARY_NAME to connect")
-                    input = it.openReadChannel()
-                    output = it.openWriteChannel()
-                    startReaderLocked(input!!)
-                    Timber.d("Started $BINARY_NAME")
+                var acceptedDaemon: ALocalSocket? = null
+                withTimeoutOrNull(10.seconds) {
+                    while (acceptedDaemon == null) {
+                        val accepted = serverSocket.accept()
+                        var acceptedByDaemon = false
+                        try {
+                            val uid = accepted.socket.peerCredentials.uid
+                            if (uid == 0) {
+                                acceptedByDaemon = true
+                                acceptedDaemon = accepted
+                            } else Timber.w("Rejected $BINARY_NAME connection from uid=$uid")
+                        } finally {
+                            if (!acceptedByDaemon) try {
+                                accepted.close()
+                            } catch (e: IOException) {
+                                Timber.w(e, "Failed to close rejected $BINARY_NAME connection")
+                            }
+                        }
+                    }
                 }
+                val daemonSocket = acceptedDaemon ?: throw IOException(
+                    "Timed out waiting for root $BINARY_NAME to connect",
+                )
+                socket = daemonSocket
+                input = daemonSocket.openReadChannel()
+                output = daemonSocket.openWriteChannel()
+                startReaderLocked(input!!)
+                Timber.d("Started $BINARY_NAME")
             }
         } catch (e: Exception) {
             try {


### PR DESCRIPTION
## Summary

- Require the accepted `vpnhotspotd` control socket peer to have Unix socket credentials with `uid=0`.
- Reject and close non-root peers while continuing to wait within the existing daemon startup timeout.
- Document the daemon control-channel ownership invariant in the lifecycle docs.

## Root Cause

The app-side daemon controller accepted the first local socket peer for the root daemon rendezvous without binding that connection to a root-owned process. That left daemon-originated event frames trusted before the control channel had authenticated the peer.

## Validation

- `./gradlew :mobile:compileDebugKotlin`
- `git diff --check`