### PR TITLE
Add gateway sharing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ Installing as system app also has the side benefit of launching root daemon less
 
 Whenever you install an app update, if there was a new protected permission addition (last updated in v2.17.1), you should update the app installed in system as well to make the system grant the privileged permission.
 
+## Gateway sharing (single-arm router)
+
+Besides sharing your VPN over a hotspot, this device can act as a gateway on an existing LAN it has joined as an ordinary client (Wi-Fi or Ethernet), forwarding other devices' traffic into the VPN. In networking terms this is a single-arm router (router-on-a-stick): the device routes traffic that arrives on the interface it is also using as a client.
+
+This is more technical to set up than a hotspot, but lets you give a whole network VPN access without making clients connect to a separate hotspot.
+
+To use it:
+
+1. Root the device and connect it to the LAN as a normal client.
+2. Connect a VPN on this device.
+3. In the app's tethering screen, under **Gateway sharing**, enable the interface that holds the LAN address (e.g. `wlan0`).
+4. On each other device, set its gateway **and DNS** to this device's IP on that LAN (statically, or via your router's DHCP). Their traffic then routes through the VPN; DNS is resolved over the VPN to avoid leaks.
+
 ## Q & A
 
 Search the [issue tracker](https://github.com/Mygod/VPNHotspot/issues) for more.

--- a/docs/vpnhotspotd/routing.md
+++ b/docs/vpnhotspotd/routing.md
@@ -214,6 +214,30 @@ Missing upstream links are skipped because upstream snapshots can race interface
 churn. Other netlink lookup errors are reported as structured nonfatals and
 that upstream interface is skipped for the current best-effort reconcile.
 
+### IPv4 Gateway Return Rule
+
+Condition: `SessionConfig.gateway` is set, for each unique resolved upstream
+interface whose name is not the downstream interface.
+
+External mutation:
+
+- replace IPv4 policy rule
+  `iif <upstream> priority <gateway-return-priority> lookup <main (254)>`
+
+Rollback:
+
+- delete the corresponding IPv4 policy rule by full rule shape.
+
+A single-arm router downstream is a physical interface this device joined as a
+LAN client, not a system tether, so netd never registers its subnet in the
+`local_network` table. VPN replies arrive on the upstream and are matched by
+netd's `iif <upstream> lookup local_network` rule, which has no route to the
+client subnet, leaving replies unreachable. This rule sends upstream-ingress
+traffic to the main table, which holds the kernel connected route for the
+downstream subnet, so replies reach the clients. Upstreams equal to the
+downstream are skipped: the fallback upstream can be the downstream itself, and
+`iif <downstream> lookup main` would hijack forward traffic.
+
 ### Netd Masquerade
 
 Condition: `SessionConfig.masquerade == MASQUERADE_MODE_NETD`, for each unique
@@ -645,6 +669,7 @@ External mutations:
 - repeatedly delete IPv4 policy rules at `<primary-priority>`.
 - repeatedly delete IPv4 policy rules at `<fallback-priority>`.
 - repeatedly delete IPv4 policy rules at `<upstream-disable-priority>`.
+- repeatedly delete IPv4 policy rules at `<gateway-return-priority>`.
 - flush IPv6 routes from table 900.
 
 For every current interface name:
@@ -714,6 +739,7 @@ tethering rules. The code names four base priorities:
 | Role | Android 12+ | Android 10/11 |
 | --- | ---: | ---: |
 | NAT66 daemon table lookup | `20600` | `17600` |
+| Gateway return table lookup | `20650` | `17650` |
 | Primary upstream table lookup | `20700` | `17700` |
 | Fallback upstream table lookup | `20800` | `17800` |
 | Downstream unreachable guard | `20900` | `17900` |
@@ -725,6 +751,8 @@ The daemon uses these table conventions:
 
 - table 900 is VPNHotspot's daemon table for NAT66 local interception;
 - table 99 is Android's shared `local_network` table;
+- table 254 is the kernel main table, looked up by the gateway return rule for
+  the downstream client subnet's connected route;
 - upstream interface tables use Android's `ifindex + 1000` convention.
 
 Table 900 may be flushed by Clean because it is reserved by VPNHotspot. Table

--- a/docs/vpnhotspotd/routing.md
+++ b/docs/vpnhotspotd/routing.md
@@ -739,7 +739,7 @@ tethering rules. The code names four base priorities:
 | Role | Android 12+ | Android 10/11 |
 | --- | ---: | ---: |
 | NAT66 daemon table lookup | `20600` | `17600` |
-| Gateway return table lookup | `20650` | `17650` |
+| Gateway return table lookup | `20500` | `17500` |
 | Primary upstream table lookup | `20700` | `17700` |
 | Fallback upstream table lookup | `20800` | `17800` |
 | Downstream unreachable guard | `20900` | `17900` |

--- a/mobile/src/main/java/be/mygod/vpnhotspot/TetheringService.kt
+++ b/mobile/src/main/java/be/mygod/vpnhotspot/TetheringService.kt
@@ -129,6 +129,7 @@ class TetheringService : NetlinkNeighbourMonitoringService() {
     }
     private suspend fun onDownstreamsChangedLocked() {
         val monitoredIfaces = MutableScatterSet<String>()
+        val monitoredGatewayIfaces = MutableScatterSet<String>()
         val gatewayIfaces = MutableScatterSet<String>()
         val inactiveIfaces = MutableScatterSet<String>()
         val managedIfaces = MutableScatterSet<String>()
@@ -141,13 +142,16 @@ class TetheringService : NetlinkNeighbourMonitoringService() {
                 monitoredIfaces.add(downstream.downstream)
                 if (!downstream.started) inactiveIfaces.add(downstream.downstream)
             }
-            if (downstream.gateway) gatewayIfaces.add(downstream.downstream)
+            if (downstream.gateway) {
+                gatewayIfaces.add(downstream.downstream)
+                if (downstream.monitor) monitoredGatewayIfaces.add(downstream.downstream)
+            }
         }
-        if (monitoredIfaces.isEmpty() && gatewayIfaces.isEmpty()) {
+        if (monitoredIfaces.isEmpty() && monitoredGatewayIfaces.isEmpty()) {
             BootReceiver.delete<TetheringService>()
         } else BootReceiver.add<TetheringService>(Starter(
             ArrayList<String>(monitoredIfaces.size).apply { monitoredIfaces.forEach { add(it) } },
-            ArrayList<String>(gatewayIfaces.size).apply { gatewayIfaces.forEach { add(it) } },
+            ArrayList<String>(monitoredGatewayIfaces.size).apply { monitoredGatewayIfaces.forEach { add(it) } },
         ))
         // Publish to the bound binder before the teardown below: when reached from the TetherStates
         // collector, unregisterReceiver() cancels tetherStatesJob — this coroutine's own parent — which
@@ -226,8 +230,8 @@ class TetheringService : NetlinkNeighbourMonitoringService() {
                 intent.getStringExtra(EXTRA_REMOVE_INTERFACE_GATEWAY)?.also { iface ->
                     downstreams[iface]?.also { downstream ->
                         downstream.gateway = false
-                        // keep it alive only if still needed as a monitor or an actively tethered downstream
-                        if (!downstream.monitor && tetheredIfaces?.contains(iface) != true) {
+                        downstream.monitor = false
+                        if (tetheredIfaces?.contains(iface) != true) {
                             downstreams.remove(iface)?.stop()
                         }
                     }

--- a/mobile/src/main/java/be/mygod/vpnhotspot/TetheringService.kt
+++ b/mobile/src/main/java/be/mygod/vpnhotspot/TetheringService.kt
@@ -62,7 +62,10 @@ class TetheringService : NetlinkNeighbourMonitoringService() {
     private class Downstream(caller: Any, downstream: String, var monitor: Boolean = false,
                              var gateway: Boolean = false) : RoutingManager(caller, downstream) {
         override fun Routing.configure() {
-            if (gateway) ipForward = true   // client interface is not a system tether; enable forwarding
+            if (this@Downstream.gateway) {
+                ipForward = true   // client interface is not a system tether; enable forwarding
+                gateway = true     // request the daemon's single-arm return-path rule
+            }
             ipv6Mode = RoutingManager.ipv6Mode
         }
     }

--- a/mobile/src/main/java/be/mygod/vpnhotspot/TetheringService.kt
+++ b/mobile/src/main/java/be/mygod/vpnhotspot/TetheringService.kt
@@ -8,10 +8,14 @@ import androidx.collection.MutableScatterSet
 import androidx.collection.ScatterSet
 import androidx.collection.emptyScatterSet
 import androidx.collection.toMutableScatterMap
+import androidx.core.content.edit
+import be.mygod.vpnhotspot.App.Companion.app
 import be.mygod.vpnhotspot.net.Routing
+import be.mygod.vpnhotspot.net.Routing.Ipv6Mode
 import be.mygod.vpnhotspot.net.TetherStates
 import be.mygod.vpnhotspot.net.TetheringManagerCompat
 import be.mygod.vpnhotspot.root.WifiApCommands
+import be.mygod.vpnhotspot.root.daemon.RaPreference
 import be.mygod.vpnhotspot.util.TileServiceDismissHandle
 import be.mygod.vpnhotspot.widget.SmartSnackbar
 import kotlinx.coroutines.Dispatchers
@@ -37,6 +41,34 @@ class TetheringService : NetlinkNeighbourMonitoringService() {
         const val EXTRA_REMOVE_INTERFACE = "interface.remove"
         const val EXTRA_REMOVE_INTERFACE_MONITOR = "interface.remove.monitor"
         const val EXTRA_REMOVE_INTERFACE_GATEWAY = "interface.remove.gateway"
+        const val EXTRA_RESTART_INTERFACE_GATEWAY = "interface.restart.gateway"
+
+        private const val KEY_GATEWAY_RA_PREFIX = "service.gateway.raPreference."
+
+        fun gatewayRaPreference(iface: String): RaPreference? {
+            val value = app.pref.getString(KEY_GATEWAY_RA_PREFIX + iface, null) ?: return null
+            return when (value) {
+                "High" -> RaPreference.RA_PREFERENCE_HIGH
+                "Medium" -> RaPreference.RA_PREFERENCE_MEDIUM
+                "Low" -> RaPreference.RA_PREFERENCE_LOW
+                else -> null
+            }
+        }
+
+        fun setGatewayRaPreference(iface: String, pref: RaPreference?) {
+            app.pref.edit {
+                if (pref == null) {
+                    remove(KEY_GATEWAY_RA_PREFIX + iface)
+                } else {
+                    putString(KEY_GATEWAY_RA_PREFIX + iface, when (pref) {
+                        RaPreference.RA_PREFERENCE_HIGH -> "High"
+                        RaPreference.RA_PREFERENCE_MEDIUM -> "Medium"
+                        RaPreference.RA_PREFERENCE_LOW -> "Low"
+                        is RaPreference.Unrecognized -> "Medium"
+                    })
+                }
+            }
+        }
 
         var dismissHandle: TileServiceDismissHandle? = null
         private fun dismissIfApplicable() = dismissHandle?.run {
@@ -65,8 +97,16 @@ class TetheringService : NetlinkNeighbourMonitoringService() {
             if (this@Downstream.gateway) {
                 ipForward = true   // client interface is not a system tether; enable forwarding
                 gateway = true     // request the daemon's single-arm return-path rule
+                val pref = gatewayRaPreference(downstream)
+                if (pref != null) {
+                    ipv6Mode = Ipv6Mode.Nat
+                    raPreference = pref
+                } else {
+                    ipv6Mode = RoutingManager.ipv6Mode
+                }
+            } else {
+                ipv6Mode = RoutingManager.ipv6Mode
             }
-            ipv6Mode = RoutingManager.ipv6Mode
         }
     }
 
@@ -234,6 +274,12 @@ class TetheringService : NetlinkNeighbourMonitoringService() {
                         if (tetheredIfaces?.contains(iface) != true) {
                             downstreams.remove(iface)?.stop()
                         }
+                    }
+                }
+                intent.getStringExtra(EXTRA_RESTART_INTERFACE_GATEWAY)?.also { iface ->
+                    downstreams[iface]?.also { downstream ->
+                        downstream.stop()
+                        downstream.start()
                     }
                 }
                 onDownstreamsChangedLocked()

--- a/mobile/src/main/java/be/mygod/vpnhotspot/TetheringService.kt
+++ b/mobile/src/main/java/be/mygod/vpnhotspot/TetheringService.kt
@@ -32,8 +32,11 @@ class TetheringService : NetlinkNeighbourMonitoringService() {
         const val EXTRA_ADD_INTERFACES = "interface.add"
         const val EXTRA_ADD_INTERFACE_MONITOR = "interface.add.monitor"
         const val EXTRA_ADD_INTERFACES_MONITOR = "interface.adds.monitor"
+        const val EXTRA_ADD_INTERFACE_GATEWAY = "interface.add.gateway"
+        const val EXTRA_ADD_INTERFACES_GATEWAY = "interface.adds.gateway"
         const val EXTRA_REMOVE_INTERFACE = "interface.remove"
         const val EXTRA_REMOVE_INTERFACE_MONITOR = "interface.remove.monitor"
+        const val EXTRA_REMOVE_INTERFACE_GATEWAY = "interface.remove.gateway"
 
         var dismissHandle: TileServiceDismissHandle? = null
         private fun dismissIfApplicable() = dismissHandle?.run {
@@ -46,22 +49,31 @@ class TetheringService : NetlinkNeighbourMonitoringService() {
         val managedIfaces = owner.managedIfaces.asStateFlow()
         val inactiveIfaces = owner.inactiveIfaceSet.asStateFlow()
         val monitoredIfaces = owner.monitoredIfaceSet.asStateFlow()
+        val gatewayIfaces = owner.gatewayIfaceSet.asStateFlow()
 
         fun isActive(iface: String) = managedIfaces.value.contains(iface)
     }
 
-    private class Downstream(caller: Any, downstream: String, var monitor: Boolean = false) :
-            RoutingManager(caller, downstream) {
+    /**
+     * [gateway] marks a single-arm router downstream: a physical interface this device joined as a LAN
+     * client. Unlike tether/monitor downstreams, its routing is gated on the interface existing rather
+     * than on system tethering state, so it starts immediately and survives [TetherStates] changes.
+     */
+    private class Downstream(caller: Any, downstream: String, var monitor: Boolean = false,
+                             var gateway: Boolean = false) : RoutingManager(caller, downstream) {
         override fun Routing.configure() {
+            if (gateway) ipForward = true   // client interface is not a system tether; enable forwarding
             ipv6Mode = RoutingManager.ipv6Mode
         }
     }
 
     @Parcelize
-    data class Starter(val monitored: ArrayList<String>) : BootReceiver.Startable {
+    data class Starter(val monitored: ArrayList<String>, val gateway: ArrayList<String> = ArrayList()) :
+            BootReceiver.Startable {
         override fun start(context: Context) {
             context.startForegroundService(Intent(context, TetheringService::class.java).apply {
-                putStringArrayListExtra(EXTRA_ADD_INTERFACES_MONITOR, monitored)
+                if (monitored.isNotEmpty()) putStringArrayListExtra(EXTRA_ADD_INTERFACES_MONITOR, monitored)
+                if (gateway.isNotEmpty()) putStringArrayListExtra(EXTRA_ADD_INTERFACES_GATEWAY, gateway)
             })
         }
     }
@@ -74,6 +86,7 @@ class TetheringService : NetlinkNeighbourMonitoringService() {
     private val managedIfaces = MutableStateFlow<ScatterSet<String>>(emptyScatterSet())
     private val inactiveIfaceSet = MutableStateFlow<ScatterSet<String>>(emptyScatterSet())
     private val monitoredIfaceSet = MutableStateFlow<ScatterSet<String>>(emptyScatterSet())
+    private val gatewayIfaceSet = MutableStateFlow<ScatterSet<String>>(emptyScatterSet())
     override val interfaces = MutableStateFlow<Interfaces?>(null)
     private val binder = Binder(this)
     private var downstreams = MutableScatterMap<String, Downstream>()
@@ -104,6 +117,7 @@ class TetheringService : NetlinkNeighbourMonitoringService() {
                 if (downstream != null && downstream.monitor && !downstream.start()) dismissIfApplicable()
             }
             toRemove.forEach { iface, downstream ->
+                if (downstream.gateway) return@forEach   // gateway downstreams are not tether-state gated
                 if (!downstream.monitor) check(downstreams.remove(iface, downstream))
                 downstream.stop()
             }
@@ -112,6 +126,7 @@ class TetheringService : NetlinkNeighbourMonitoringService() {
     }
     private suspend fun onDownstreamsChangedLocked() {
         val monitoredIfaces = MutableScatterSet<String>()
+        val gatewayIfaces = MutableScatterSet<String>()
         val inactiveIfaces = MutableScatterSet<String>()
         val managedIfaces = MutableScatterSet<String>()
         val active = ArrayList<String>(downstreams.size)
@@ -123,19 +138,20 @@ class TetheringService : NetlinkNeighbourMonitoringService() {
                 monitoredIfaces.add(downstream.downstream)
                 if (!downstream.started) inactiveIfaces.add(downstream.downstream)
             }
+            if (downstream.gateway) gatewayIfaces.add(downstream.downstream)
         }
-        monitoredIfaces.also { ifaces ->
-            if (ifaces.isEmpty()) {
-                BootReceiver.delete<TetheringService>()
-            } else BootReceiver.add<TetheringService>(Starter(ArrayList<String>(ifaces.size).apply {
-                ifaces.forEach { iface -> add(iface) }
-            }))
-        }
+        if (monitoredIfaces.isEmpty() && gatewayIfaces.isEmpty()) {
+            BootReceiver.delete<TetheringService>()
+        } else BootReceiver.add<TetheringService>(Starter(
+            ArrayList<String>(monitoredIfaces.size).apply { monitoredIfaces.forEach { add(it) } },
+            ArrayList<String>(gatewayIfaces.size).apply { gatewayIfaces.forEach { add(it) } },
+        ))
         // Publish to the bound binder before the teardown below: when reached from the TetherStates
         // collector, unregisterReceiver() cancels tetherStatesJob — this coroutine's own parent — which
         // would otherwise skip this withContext and leave stale managedIfaces visible to bound UI.
         withContext(Dispatchers.Main) {
             monitoredIfaceSet.value = monitoredIfaces
+            gatewayIfaceSet.value = gatewayIfaces
             inactiveIfaceSet.value = inactiveIfaces
             this@TetheringService.managedIfaces.value = managedIfaces
         }
@@ -182,11 +198,35 @@ class TetheringService : NetlinkNeighbourMonitoringService() {
                     }
                     if (downstreamToStart?.start() == false) dismissIfApplicable()
                 }
+                val gatewayList = intent.getStringArrayListExtra(EXTRA_ADD_INTERFACES_GATEWAY) ?:
+                    intent.getStringExtra(EXTRA_ADD_INTERFACE_GATEWAY)?.let { listOf(it) }
+                if (!gatewayList.isNullOrEmpty()) for (iface in gatewayList) {
+                    var downstreamToStart: Downstream? = null
+                    downstreams.compute(iface) { _, downstream ->
+                        if (downstream == null) {
+                            Downstream(this@TetheringService, iface, gateway = true).also { downstreamToStart = it }
+                        } else {
+                            downstream.gateway = true
+                            if (!downstream.started) downstreamToStart = downstream
+                            downstream
+                        }
+                    }
+                    if (downstreamToStart?.start() == false) dismissIfApplicable()
+                }
                 intent.getStringExtra(EXTRA_REMOVE_INTERFACE)?.also { downstreams.remove(it)?.stop() }
                 intent.getStringExtra(EXTRA_REMOVE_INTERFACE_MONITOR)?.also { iface ->
                     downstreams[iface]?.also { downstream ->
                         downstream.monitor = false
                         if (!downstream.started) downstreams.remove(iface)?.stop()
+                    }
+                }
+                intent.getStringExtra(EXTRA_REMOVE_INTERFACE_GATEWAY)?.also { iface ->
+                    downstreams[iface]?.also { downstream ->
+                        downstream.gateway = false
+                        // keep it alive only if still needed as a monitor or an actively tethered downstream
+                        if (!downstream.monitor && tetheredIfaces?.contains(iface) != true) {
+                            downstreams.remove(iface)?.stop()
+                        }
                     }
                 }
                 onDownstreamsChangedLocked()

--- a/mobile/src/main/java/be/mygod/vpnhotspot/net/Routing.kt
+++ b/mobile/src/main/java/be/mygod/vpnhotspot/net/Routing.kt
@@ -21,6 +21,7 @@ import be.mygod.vpnhotspot.root.daemon.DaemonController
 import be.mygod.vpnhotspot.root.daemon.Ipv6NatConfig
 import be.mygod.vpnhotspot.root.daemon.Ipv6Prefix
 import be.mygod.vpnhotspot.root.daemon.MasqueradeMode
+import be.mygod.vpnhotspot.root.daemon.RaPreference
 import be.mygod.vpnhotspot.root.daemon.SessionConfig
 import be.mygod.vpnhotspot.util.allInterfaceNames
 import be.mygod.vpnhotspot.util.allRoutes
@@ -84,6 +85,7 @@ class Routing(private val caller: Any, private val downstream: String) {
      * clients on a physical interface this device joined as a LAN client (not a system tether).
      */
     var gateway = false
+    var raPreference: RaPreference = RaPreference.RA_PREFERENCE_MEDIUM
 
     private val fallbackUpstream = UpstreamTracker()
     private val primaryUpstream = UpstreamTracker()
@@ -336,7 +338,7 @@ class Routing(private val caller: Any, private val downstream: String) {
                     ))
                 }
             },
-            ipv6_nat = if (ipv6Mode == Ipv6Mode.Nat) Ipv6NatConfig(ipv6NatPrefixSeed) else null,
+            ipv6_nat = if (ipv6Mode == Ipv6Mode.Nat) Ipv6NatConfig(ipv6NatPrefixSeed, raPreference) else null,
             gateway = gateway,
         )
     }

--- a/mobile/src/main/java/be/mygod/vpnhotspot/net/Routing.kt
+++ b/mobile/src/main/java/be/mygod/vpnhotspot/net/Routing.kt
@@ -79,6 +79,11 @@ class Routing(private val caller: Any, private val downstream: String) {
     var ipForward = false
     var ipv6Mode = Ipv6Mode.System
     var masqueradeMode: MasqueradeMode = MasqueradeMode.MASQUERADE_MODE_NONE
+    /**
+     * Single-arm router downstream: enables a return-path rule in the daemon so VPN replies reach
+     * clients on a physical interface this device joined as a LAN client (not a system tether).
+     */
+    var gateway = false
 
     private val fallbackUpstream = UpstreamTracker()
     private val primaryUpstream = UpstreamTracker()
@@ -332,6 +337,7 @@ class Routing(private val caller: Any, private val downstream: String) {
                 }
             },
             ipv6_nat = if (ipv6Mode == Ipv6Mode.Nat) Ipv6NatConfig(ipv6NatPrefixSeed) else null,
+            gateway = gateway,
         )
     }
 

--- a/mobile/src/main/java/be/mygod/vpnhotspot/ui/TetheringScreen.kt
+++ b/mobile/src/main/java/be/mygod/vpnhotspot/ui/TetheringScreen.kt
@@ -159,13 +159,13 @@ fun TetheringScreen(
     val tetheredTypes = remember(tetherStates, tetherTypeVersion) {
         tetherStates.tethered.map { TetherType.ofInterface(it) }.toSet()
     }
-    val interfaceIfaces = remember(tetherStates, monitored) {
-        (tetherStates.tethered + monitored).toSortedSet().toList()
+    val interfaceIfaces = remember(tetherStates, monitored, gateway) {
+        (tetherStates.tethered + monitored - gateway).toSortedSet().toList()
     }
     // Single-arm router candidates: up physical interfaces with an IPv4 that this device joined as a
     // client. Exclude interfaces already shown above (tethered/monitored); always include active ones.
     val gatewayCandidates = remember(ifaceLookup, tetherStates, monitored, gateway) {
-        val exclude = tetherStates.tethered + monitored
+        val exclude = tetherStates.tethered + (monitored - gateway)
         (ifaceLookup.values.asSequence().filter { iface ->
             try {
                 iface.isUp && !iface.isLoopback && !iface.isPointToPoint &&
@@ -459,7 +459,8 @@ fun TetheringScreen(
             }
             if (gatewayExpanded || gateway.isNotEmpty()) for (iface in gatewayCandidates) {
                 val active = gateway.contains(iface)
-                if (!gatewayExpanded && !active) continue
+                val watch = monitored.contains(iface)
+                if (!gatewayExpanded && !active && !watch) continue
                 row("gateway_$iface") {
                     TetheringRow(
                         icon = TetherType.ofInterface(iface).icon,
@@ -471,6 +472,23 @@ fun TetheringScreen(
                                 .putExtra(TetheringService.EXTRA_REMOVE_INTERFACE_GATEWAY, iface))
                             else context.startForegroundService(Intent(context, TetheringService::class.java)
                                 .putExtra(TetheringService.EXTRA_ADD_INTERFACE_GATEWAY, iface))
+                        },
+                    )
+                }
+                if (active || watch) row("gateway_watch_$iface") {
+                    PreferenceRow(
+                        title = stringResource(R.string.tethering_watch_reconnect),
+                        trailing = {
+                            PreferenceSwitch(
+                                checked = watch,
+                                onCheckedChange = null,
+                            )
+                        },
+                        onClick = {
+                            if (watch) context.startService(Intent(context, TetheringService::class.java)
+                                .putExtra(TetheringService.EXTRA_REMOVE_INTERFACE_MONITOR, iface))
+                            else context.startForegroundService(Intent(context, TetheringService::class.java)
+                                .putExtra(TetheringService.EXTRA_ADD_INTERFACE_MONITOR, iface))
                         },
                     )
                 }

--- a/mobile/src/main/java/be/mygod/vpnhotspot/ui/TetheringScreen.kt
+++ b/mobile/src/main/java/be/mygod/vpnhotspot/ui/TetheringScreen.kt
@@ -381,7 +381,6 @@ fun TetheringScreen(
                     icon = R.drawable.ic_lan,
                     iconTint = MaterialTheme.colorScheme.secondary,
                     title = stringResource(R.string.tethering_gateway),
-                    summary = stringResource(R.string.tethering_gateway_summary),
                 )
             }
             if (gatewayCandidates.isEmpty()) {

--- a/mobile/src/main/java/be/mygod/vpnhotspot/ui/TetheringScreen.kt
+++ b/mobile/src/main/java/be/mygod/vpnhotspot/ui/TetheringScreen.kt
@@ -90,6 +90,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.lang.reflect.InvocationTargetException
+import java.net.Inet4Address
 import java.net.NetworkInterface
 import java.net.SocketException
 import java.text.NumberFormat
@@ -99,6 +100,7 @@ data class TetheringServiceState(
     val managedIfaces: Set<String> = emptySet(),
     val inactiveIfaces: Set<String> = emptySet(),
     val monitoredIfaces: Set<String> = emptySet(),
+    val gatewayIfaces: Set<String> = emptySet(),
 )
 
 @Composable
@@ -152,11 +154,26 @@ fun TetheringScreen(
     val monitored = tetheringServiceState.monitoredIfaces
     val managed = tetheringServiceState.managedIfaces
     val inactive = tetheringServiceState.inactiveIfaces
+    val gateway = tetheringServiceState.gatewayIfaces
     val tetheredTypes = remember(tetherStates, tetherTypeVersion) {
         tetherStates.tethered.map { TetherType.ofInterface(it) }.toSet()
     }
     val interfaceIfaces = remember(tetherStates, monitored) {
         (tetherStates.tethered + monitored).toSortedSet().toList()
+    }
+    // Single-arm router candidates: up physical interfaces with an IPv4 that this device joined as a
+    // client. Exclude interfaces already shown above (tethered/monitored); always include active ones.
+    val gatewayCandidates = remember(ifaceLookup, tetherStates, monitored, gateway) {
+        val exclude = tetherStates.tethered + monitored
+        (ifaceLookup.values.asSequence().filter { iface ->
+            try {
+                iface.isUp && !iface.isLoopback && !iface.isPointToPoint &&
+                        iface.interfaceAddresses.any { it.address is Inet4Address }
+            } catch (e: SocketException) {
+                Timber.d(e)
+                false
+            }
+        }.map { it.name }.toSet() + gateway - exclude).toSortedSet().toList()
     }
     val wifiBaseError = tetherError(context, tetherStates, TetherType.WIFI)
     val wifiSummary by if (inspectionMode) {
@@ -355,6 +372,40 @@ fun TetheringScreen(
                             },
                         )
                     }
+                }
+            }
+        }
+        preferenceGroup(key = "gateway") {
+            row(R.string.tethering_gateway) {
+                PreferenceRow(
+                    icon = R.drawable.ic_lan,
+                    iconTint = MaterialTheme.colorScheme.secondary,
+                    title = stringResource(R.string.tethering_gateway),
+                    summary = stringResource(R.string.tethering_gateway_summary),
+                )
+            }
+            if (gatewayCandidates.isEmpty()) {
+                row("gateway_empty") {
+                    PreferenceRow(
+                        modifier = Modifier.padding(start = 48.dp),
+                        title = stringResource(R.string.tethering_gateway_empty),
+                    )
+                }
+            } else for (iface in gatewayCandidates) {
+                row("gateway_$iface") {
+                    val active = gateway.contains(iface)
+                    TetheringRow(
+                        icon = TetherType.ofInterface(iface).icon,
+                        title = iface,
+                        summary = networkInterfaceAddressesText(ifaceLookup[iface], linkStyles),
+                        checked = active,
+                        onClick = {
+                            if (active) context.startService(Intent(context, TetheringService::class.java)
+                                .putExtra(TetheringService.EXTRA_REMOVE_INTERFACE_GATEWAY, iface))
+                            else context.startForegroundService(Intent(context, TetheringService::class.java)
+                                .putExtra(TetheringService.EXTRA_ADD_INTERFACE_GATEWAY, iface))
+                        },
+                    )
                 }
             }
         }

--- a/mobile/src/main/java/be/mygod/vpnhotspot/ui/TetheringScreen.kt
+++ b/mobile/src/main/java/be/mygod/vpnhotspot/ui/TetheringScreen.kt
@@ -80,6 +80,7 @@ import be.mygod.vpnhotspot.net.TetheringManagerCompat
 import be.mygod.vpnhotspot.net.wifi.WifiApManager
 import be.mygod.vpnhotspot.net.wifi.WifiP2pManagerHelper
 import be.mygod.vpnhotspot.root.WifiApCommands
+import be.mygod.vpnhotspot.root.daemon.RaPreference
 import be.mygod.vpnhotspot.ui.apconfiguration.VendorData
 import be.mygod.vpnhotspot.ui.theme.VpnHotspotPreviewSurface
 import be.mygod.vpnhotspot.util.Services
@@ -489,6 +490,35 @@ fun TetheringScreen(
                                 .putExtra(TetheringService.EXTRA_REMOVE_INTERFACE_MONITOR, iface))
                             else context.startForegroundService(Intent(context, TetheringService::class.java)
                                 .putExtra(TetheringService.EXTRA_ADD_INTERFACE_MONITOR, iface))
+                        },
+                    )
+                }
+                if (active) row("gateway_ra_$iface") {
+                    val raEntries = listOf(
+                        null to stringResource(R.string.tethering_gateway_ra_disabled),
+                        RaPreference.RA_PREFERENCE_HIGH to stringResource(R.string.tethering_gateway_ra_high),
+                        RaPreference.RA_PREFERENCE_MEDIUM to stringResource(R.string.tethering_gateway_ra_medium),
+                        RaPreference.RA_PREFERENCE_LOW to stringResource(R.string.tethering_gateway_ra_low),
+                    )
+                    val currentPref = TetheringService.gatewayRaPreference(iface)
+                    val selectedIndex = raEntries.indexOfFirst { it.first == currentPref }
+                    var selectingRa by rememberSaveable { mutableStateOf(false) }
+                    PreferenceRow(
+                        title = stringResource(R.string.tethering_gateway_ra_preference),
+                        summary = raEntries[if (selectedIndex >= 0) selectedIndex else 0].second,
+                        onClick = { selectingRa = true },
+                    )
+                    if (selectingRa) PreferenceSelectionSheet(
+                        title = stringResource(R.string.tethering_gateway_ra_preference),
+                        entryCount = raEntries.size,
+                        selectedIndex = if (selectedIndex >= 0) selectedIndex else 0,
+                        entryLabel = { raEntries[it].second },
+                        onDismissRequest = { selectingRa = false },
+                        onSelect = {
+                            TetheringService.setGatewayRaPreference(iface, raEntries[it].first)
+                            selectingRa = false
+                            context.startForegroundService(Intent(context, TetheringService::class.java)
+                                .putExtra(TetheringService.EXTRA_RESTART_INTERFACE_GATEWAY, iface))
                         },
                     )
                 }

--- a/mobile/src/main/java/be/mygod/vpnhotspot/ui/TetheringScreen.kt
+++ b/mobile/src/main/java/be/mygod/vpnhotspot/ui/TetheringScreen.kt
@@ -495,7 +495,7 @@ fun TetheringScreen(
                 }
                 if (active) row("gateway_ra_$iface") {
                     val raEntries = listOf(
-                        null to stringResource(R.string.tethering_gateway_ra_disabled),
+                        null to stringResource(R.string.tethering_gateway_ra_follow_global),
                         RaPreference.RA_PREFERENCE_HIGH to stringResource(R.string.tethering_gateway_ra_high),
                         RaPreference.RA_PREFERENCE_MEDIUM to stringResource(R.string.tethering_gateway_ra_medium),
                         RaPreference.RA_PREFERENCE_LOW to stringResource(R.string.tethering_gateway_ra_low),

--- a/mobile/src/main/java/be/mygod/vpnhotspot/ui/TetheringScreen.kt
+++ b/mobile/src/main/java/be/mygod/vpnhotspot/ui/TetheringScreen.kt
@@ -136,6 +136,7 @@ fun TetheringScreen(
         TextFieldState(staticIpDraft.orEmpty())
     }
     var wpsDialog by rememberSaveable { mutableStateOf(false) }
+    var gatewayExpanded by rememberSaveable { mutableStateOf(false) }
     var wpsPin by rememberTextFieldValueAtEnd("", wpsDialog)
     val tetherTypeVersion by if (inspectionMode) remember { mutableIntStateOf(0) } else rememberTetherTypeVersion()
     var manageBarVersion by remember { mutableIntStateOf(0) }
@@ -375,39 +376,6 @@ fun TetheringScreen(
                 }
             }
         }
-        preferenceGroup(key = "gateway") {
-            row(R.string.tethering_gateway) {
-                PreferenceRow(
-                    icon = R.drawable.ic_lan,
-                    iconTint = MaterialTheme.colorScheme.secondary,
-                    title = stringResource(R.string.tethering_gateway),
-                )
-            }
-            if (gatewayCandidates.isEmpty()) {
-                row("gateway_empty") {
-                    PreferenceRow(
-                        modifier = Modifier.padding(start = 48.dp),
-                        title = stringResource(R.string.tethering_gateway_empty),
-                    )
-                }
-            } else for (iface in gatewayCandidates) {
-                row("gateway_$iface") {
-                    val active = gateway.contains(iface)
-                    TetheringRow(
-                        icon = TetherType.ofInterface(iface).icon,
-                        title = iface,
-                        summary = networkInterfaceAddressesText(ifaceLookup[iface], linkStyles),
-                        checked = active,
-                        onClick = {
-                            if (active) context.startService(Intent(context, TetheringService::class.java)
-                                .putExtra(TetheringService.EXTRA_REMOVE_INTERFACE_GATEWAY, iface))
-                            else context.startForegroundService(Intent(context, TetheringService::class.java)
-                                .putExtra(TetheringService.EXTRA_ADD_INTERFACE_GATEWAY, iface))
-                        },
-                    )
-                }
-            }
-        }
         preferenceGroup(key = "manage_tethering") {
             row(R.string.tethering_manage) {
                 PreferenceRow(
@@ -469,6 +437,43 @@ fun TetheringScreen(
                     tetheringType = TetheringManagerCompat.TETHERING_ETHERNET,
                     snackbarHostState = snackbarHostState,
                 )
+            }
+        }
+        preferenceGroup(key = "gateway") {
+            row(R.string.tethering_gateway) {
+                val activeGateways = gatewayCandidates.filter { gateway.contains(it) }
+                PreferenceRow(
+                    icon = R.drawable.ic_lan,
+                    iconTint = MaterialTheme.colorScheme.secondary,
+                    title = stringResource(R.string.tethering_gateway),
+                    summary = when {
+                        gatewayCandidates.isEmpty() -> stringResource(R.string.tethering_gateway_empty)
+                        activeGateways.isNotEmpty() -> activeGateways.joinToString()
+                        else -> null
+                    },
+                    enabled = gatewayCandidates.isNotEmpty(),
+                    onClick = if (gatewayCandidates.isNotEmpty()) {
+                        { gatewayExpanded = !gatewayExpanded }
+                    } else null,
+                )
+            }
+            if (gatewayExpanded || gateway.isNotEmpty()) for (iface in gatewayCandidates) {
+                val active = gateway.contains(iface)
+                if (!gatewayExpanded && !active) continue
+                row("gateway_$iface") {
+                    TetheringRow(
+                        icon = TetherType.ofInterface(iface).icon,
+                        title = iface,
+                        summary = networkInterfaceAddressesText(ifaceLookup[iface], linkStyles),
+                        checked = active,
+                        onClick = {
+                            if (active) context.startService(Intent(context, TetheringService::class.java)
+                                .putExtra(TetheringService.EXTRA_REMOVE_INTERFACE_GATEWAY, iface))
+                            else context.startForegroundService(Intent(context, TetheringService::class.java)
+                                .putExtra(TetheringService.EXTRA_ADD_INTERFACE_GATEWAY, iface))
+                        },
+                    )
+                }
             }
         }
     }

--- a/mobile/src/main/java/be/mygod/vpnhotspot/ui/VpnHotspotApp.kt
+++ b/mobile/src/main/java/be/mygod/vpnhotspot/ui/VpnHotspotApp.kt
@@ -167,10 +167,12 @@ fun VpnHotspotApp(clientViewModel: ClientViewModel) {
             val managedIfaces by binder.managedIfaces.collectAsStateWithLifecycle()
             val inactiveIfaces by binder.inactiveIfaces.collectAsStateWithLifecycle()
             val monitoredIfaces by binder.monitoredIfaces.collectAsStateWithLifecycle()
+            val gatewayIfaces by binder.gatewayIfaces.collectAsStateWithLifecycle()
             TetheringServiceState(
                 managedIfaces = managedIfaces.asSet(),
                 inactiveIfaces = inactiveIfaces.asSet(),
                 monitoredIfaces = monitoredIfaces.asSet(),
+                gatewayIfaces = gatewayIfaces.asSet(),
             )
         }
     }

--- a/mobile/src/main/proto/daemon.proto
+++ b/mobile/src/main/proto/daemon.proto
@@ -55,6 +55,9 @@ message SessionConfig {
   repeated string fallback_upstream_interfaces = 9;
   repeated ClientConfig clients = 10;
   optional Ipv6NatConfig ipv6_nat = 11;
+  // Single-arm router (gateway) downstream: a physical interface this device joined as a LAN client.
+  // Enables a return-path rule so VPN replies reach downstream clients (see routing/desired.rs).
+  bool gateway = 12;
 }
 
 enum MasqueradeMode {

--- a/mobile/src/main/proto/daemon.proto
+++ b/mobile/src/main/proto/daemon.proto
@@ -73,6 +73,13 @@ message ClientConfig {
 
 message Ipv6NatConfig {
   string prefix_seed = 1;
+  RaPreference ra_preference = 2;
+}
+
+enum RaPreference {
+  RA_PREFERENCE_MEDIUM = 0;
+  RA_PREFERENCE_HIGH = 1;
+  RA_PREFERENCE_LOW = 2;
 }
 
 message Ipv6Prefix {

--- a/mobile/src/main/res/values-ja/strings.xml
+++ b/mobile/src/main/res/values-ja/strings.xml
@@ -58,10 +58,8 @@
   <string name="tethering_temp_hotspot_failure_incompatible_mode">互換性のないモード</string>
   <string name="tethering_temp_hotspot_failure_tethering_disallowed">テザリングは許可されていません</string>
   <string name="tethering_watch_reconnect">再接続を監視</string>
-
   <string name="tethering_gateway">ゲートウェイ共有</string>
   <string name="tethering_gateway_empty">対象のインターフェースがありません（IPv4 アドレスを持つ有効なインターフェースが必要です）。</string>
-
   <string name="tethering_manage">システムのテザリングを管理…</string>
   <string name="tethering_manage_offload_enabled">VPN テザリングが機能しない場合は、開発者オプションから
         テザリング時のハードウェア アクセラレーションを無効化してください</string>

--- a/mobile/src/main/res/values-ja/strings.xml
+++ b/mobile/src/main/res/values-ja/strings.xml
@@ -61,7 +61,7 @@
   <string name="tethering_gateway">ゲートウェイ共有</string>
   <string name="tethering_gateway_empty">対象のインターフェースがありません（IPv4 アドレスを持つ有効なインターフェースが必要です）。</string>
   <string name="tethering_gateway_ra_preference">IPv6 NAT66 / RA 優先度</string>
-  <string name="tethering_gateway_ra_follow_global">グローバル設定に従う</string>
+  <string name="tethering_gateway_ra_follow_global">グローバル IPv6 モードに従う</string>
   <string name="tethering_gateway_ra_high">高</string>
   <string name="tethering_gateway_ra_medium">中</string>
   <string name="tethering_gateway_ra_low">低</string>

--- a/mobile/src/main/res/values-ja/strings.xml
+++ b/mobile/src/main/res/values-ja/strings.xml
@@ -58,6 +58,10 @@
   <string name="tethering_temp_hotspot_failure_incompatible_mode">互換性のないモード</string>
   <string name="tethering_temp_hotspot_failure_tethering_disallowed">テザリングは許可されていません</string>
   <string name="tethering_watch_reconnect">再接続を監視</string>
+
+  <string name="tethering_gateway">ゲートウェイ共有</string>
+  <string name="tethering_gateway_empty">対象のインターフェースがありません（IPv4 アドレスを持つ有効なインターフェースが必要です）。</string>
+
   <string name="tethering_manage">システムのテザリングを管理…</string>
   <string name="tethering_manage_offload_enabled">VPN テザリングが機能しない場合は、開発者オプションから
         テザリング時のハードウェア アクセラレーションを無効化してください</string>

--- a/mobile/src/main/res/values-ja/strings.xml
+++ b/mobile/src/main/res/values-ja/strings.xml
@@ -61,7 +61,7 @@
   <string name="tethering_gateway">ゲートウェイ共有</string>
   <string name="tethering_gateway_empty">対象のインターフェースがありません（IPv4 アドレスを持つ有効なインターフェースが必要です）。</string>
   <string name="tethering_gateway_ra_preference">IPv6 NAT66 / RA 優先度</string>
-  <string name="tethering_gateway_ra_disabled">無効</string>
+  <string name="tethering_gateway_ra_follow_global">グローバル設定に従う</string>
   <string name="tethering_gateway_ra_high">高</string>
   <string name="tethering_gateway_ra_medium">中</string>
   <string name="tethering_gateway_ra_low">低</string>

--- a/mobile/src/main/res/values-ja/strings.xml
+++ b/mobile/src/main/res/values-ja/strings.xml
@@ -60,6 +60,11 @@
   <string name="tethering_watch_reconnect">再接続を監視</string>
   <string name="tethering_gateway">ゲートウェイ共有</string>
   <string name="tethering_gateway_empty">対象のインターフェースがありません（IPv4 アドレスを持つ有効なインターフェースが必要です）。</string>
+  <string name="tethering_gateway_ra_preference">IPv6 NAT66 / RA 優先度</string>
+  <string name="tethering_gateway_ra_disabled">無効</string>
+  <string name="tethering_gateway_ra_high">高</string>
+  <string name="tethering_gateway_ra_medium">中</string>
+  <string name="tethering_gateway_ra_low">低</string>
   <string name="tethering_manage">システムのテザリングを管理…</string>
   <string name="tethering_manage_offload_enabled">VPN テザリングが機能しない場合は、開発者オプションから
         テザリング時のハードウェア アクセラレーションを無効化してください</string>

--- a/mobile/src/main/res/values-zh-rCN/strings.xml
+++ b/mobile/src/main/res/values-zh-rCN/strings.xml
@@ -41,6 +41,8 @@
   <string name="tethering_temp_hotspot_failure_incompatible_mode">模式不兼容</string>
   <string name="tethering_temp_hotspot_failure_tethering_disallowed">不允许网络共享</string>
   <string name="tethering_watch_reconnect">监视重新连接</string>
+  <string name="tethering_gateway">网关共享</string>
+  <string name="tethering_gateway_empty">没有可用接口（需要一个已启用且带 IPv4 地址的接口）。</string>
   <string name="tethering_manage">管理系统共享…</string>
   <string name="tethering_manage_offload_enabled">若 VPN 共享无法使用，请尝试禁用“开发者选项”中的“网络共享硬件加速”。</string>
   <string name="tethering_manage_usb">USB 网络共享</string>

--- a/mobile/src/main/res/values-zh-rCN/strings.xml
+++ b/mobile/src/main/res/values-zh-rCN/strings.xml
@@ -43,6 +43,11 @@
   <string name="tethering_watch_reconnect">监视重新连接</string>
   <string name="tethering_gateway">网关共享</string>
   <string name="tethering_gateway_empty">没有可用接口（需要一个已启用且带 IPv4 地址的接口）。</string>
+  <string name="tethering_gateway_ra_preference">IPv6 NAT66 / RA 优先级</string>
+  <string name="tethering_gateway_ra_disabled">禁用</string>
+  <string name="tethering_gateway_ra_high">高</string>
+  <string name="tethering_gateway_ra_medium">中</string>
+  <string name="tethering_gateway_ra_low">低</string>
   <string name="tethering_manage">管理系统共享…</string>
   <string name="tethering_manage_offload_enabled">若 VPN 共享无法使用，请尝试禁用“开发者选项”中的“网络共享硬件加速”。</string>
   <string name="tethering_manage_usb">USB 网络共享</string>

--- a/mobile/src/main/res/values-zh-rCN/strings.xml
+++ b/mobile/src/main/res/values-zh-rCN/strings.xml
@@ -44,7 +44,7 @@
   <string name="tethering_gateway">网关共享</string>
   <string name="tethering_gateway_empty">没有可用接口（需要一个已启用且带 IPv4 地址的接口）。</string>
   <string name="tethering_gateway_ra_preference">IPv6 NAT66 / RA 优先级</string>
-  <string name="tethering_gateway_ra_follow_global">跟随全局设置</string>
+  <string name="tethering_gateway_ra_follow_global">跟随全局 IPv6 模式</string>
   <string name="tethering_gateway_ra_high">高</string>
   <string name="tethering_gateway_ra_medium">中</string>
   <string name="tethering_gateway_ra_low">低</string>

--- a/mobile/src/main/res/values-zh-rCN/strings.xml
+++ b/mobile/src/main/res/values-zh-rCN/strings.xml
@@ -44,7 +44,7 @@
   <string name="tethering_gateway">网关共享</string>
   <string name="tethering_gateway_empty">没有可用接口（需要一个已启用且带 IPv4 地址的接口）。</string>
   <string name="tethering_gateway_ra_preference">IPv6 NAT66 / RA 优先级</string>
-  <string name="tethering_gateway_ra_disabled">禁用</string>
+  <string name="tethering_gateway_ra_follow_global">跟随全局设置</string>
   <string name="tethering_gateway_ra_high">高</string>
   <string name="tethering_gateway_ra_medium">中</string>
   <string name="tethering_gateway_ra_low">低</string>

--- a/mobile/src/main/res/values-zh-rHK/strings.xml
+++ b/mobile/src/main/res/values-zh-rHK/strings.xml
@@ -43,7 +43,7 @@
   <string name="tethering_gateway">閘道共享</string>
   <string name="tethering_gateway_empty">沒有可用介面（需要一個已啟用且帶 IPv4 位址的介面）。</string>
   <string name="tethering_gateway_ra_preference">IPv6 NAT66 / RA 優先順序</string>
-  <string name="tethering_gateway_ra_disabled">停用</string>
+  <string name="tethering_gateway_ra_follow_global">跟隨全域設定</string>
   <string name="tethering_gateway_ra_high">高</string>
   <string name="tethering_gateway_ra_medium">中</string>
   <string name="tethering_gateway_ra_low">低</string>

--- a/mobile/src/main/res/values-zh-rHK/strings.xml
+++ b/mobile/src/main/res/values-zh-rHK/strings.xml
@@ -40,6 +40,8 @@
   <string name="tethering_temp_hotspot_failure_incompatible_mode">模式不相容</string>
   <string name="tethering_temp_hotspot_failure_tethering_disallowed">不允許網絡共享</string>
   <string name="tethering_watch_reconnect">監察重新連線</string>
+  <string name="tethering_gateway">閘道共享</string>
+  <string name="tethering_gateway_empty">沒有可用介面（需要一個已啟用且帶 IPv4 位址的介面）。</string>
   <string name="tethering_manage">管理系統網絡共享…</string>
   <string name="tethering_manage_offload_enabled">如果 VPN 網絡共享無法運作，請在開發人員選項中停用網絡共享硬件加速。</string>
   <string name="tethering_manage_usb">USB 網絡共享</string>

--- a/mobile/src/main/res/values-zh-rHK/strings.xml
+++ b/mobile/src/main/res/values-zh-rHK/strings.xml
@@ -42,6 +42,11 @@
   <string name="tethering_watch_reconnect">監察重新連線</string>
   <string name="tethering_gateway">閘道共享</string>
   <string name="tethering_gateway_empty">沒有可用介面（需要一個已啟用且帶 IPv4 位址的介面）。</string>
+  <string name="tethering_gateway_ra_preference">IPv6 NAT66 / RA 優先順序</string>
+  <string name="tethering_gateway_ra_disabled">停用</string>
+  <string name="tethering_gateway_ra_high">高</string>
+  <string name="tethering_gateway_ra_medium">中</string>
+  <string name="tethering_gateway_ra_low">低</string>
   <string name="tethering_manage">管理系統網絡共享…</string>
   <string name="tethering_manage_offload_enabled">如果 VPN 網絡共享無法運作，請在開發人員選項中停用網絡共享硬件加速。</string>
   <string name="tethering_manage_usb">USB 網絡共享</string>

--- a/mobile/src/main/res/values-zh-rHK/strings.xml
+++ b/mobile/src/main/res/values-zh-rHK/strings.xml
@@ -43,7 +43,7 @@
   <string name="tethering_gateway">閘道共享</string>
   <string name="tethering_gateway_empty">沒有可用介面（需要一個已啟用且帶 IPv4 位址的介面）。</string>
   <string name="tethering_gateway_ra_preference">IPv6 NAT66 / RA 優先順序</string>
-  <string name="tethering_gateway_ra_follow_global">跟隨全域設定</string>
+  <string name="tethering_gateway_ra_follow_global">跟隨全域 IPv6 模式</string>
   <string name="tethering_gateway_ra_high">高</string>
   <string name="tethering_gateway_ra_medium">中</string>
   <string name="tethering_gateway_ra_low">低</string>

--- a/mobile/src/main/res/values-zh-rTW/strings.xml
+++ b/mobile/src/main/res/values-zh-rTW/strings.xml
@@ -53,6 +53,11 @@
   <string name="tethering_watch_reconnect">監控重新連線</string>
   <string name="tethering_gateway">閘道共用</string>
   <string name="tethering_gateway_empty">沒有可用介面（需要一個已啟用且帶 IPv4 位址的介面）。</string>
+  <string name="tethering_gateway_ra_preference">IPv6 NAT66 / RA 優先順序</string>
+  <string name="tethering_gateway_ra_disabled">停用</string>
+  <string name="tethering_gateway_ra_high">高</string>
+  <string name="tethering_gateway_ra_medium">中</string>
+  <string name="tethering_gateway_ra_low">低</string>
   <string name="tethering_manage">系統網路共用管理…</string>
   <string name="tethering_manage_offload_enabled">若 VPN 網路共用無法運作，請在「開發人員選項」中關閉「網路共用硬體加速」。</string>
   <string name="tethering_manage_usb">USB 網路共用</string>

--- a/mobile/src/main/res/values-zh-rTW/strings.xml
+++ b/mobile/src/main/res/values-zh-rTW/strings.xml
@@ -54,7 +54,7 @@
   <string name="tethering_gateway">閘道共用</string>
   <string name="tethering_gateway_empty">沒有可用介面（需要一個已啟用且帶 IPv4 位址的介面）。</string>
   <string name="tethering_gateway_ra_preference">IPv6 NAT66 / RA 優先順序</string>
-  <string name="tethering_gateway_ra_disabled">停用</string>
+  <string name="tethering_gateway_ra_follow_global">依照全域設定</string>
   <string name="tethering_gateway_ra_high">高</string>
   <string name="tethering_gateway_ra_medium">中</string>
   <string name="tethering_gateway_ra_low">低</string>

--- a/mobile/src/main/res/values-zh-rTW/strings.xml
+++ b/mobile/src/main/res/values-zh-rTW/strings.xml
@@ -51,6 +51,8 @@
   <string name="tethering_temp_hotspot_failure_incompatible_mode">模式不相容</string>
   <string name="tethering_temp_hotspot_failure_tethering_disallowed">不允許網路共享</string>
   <string name="tethering_watch_reconnect">監控重新連線</string>
+  <string name="tethering_gateway">閘道共用</string>
+  <string name="tethering_gateway_empty">沒有可用介面（需要一個已啟用且帶 IPv4 位址的介面）。</string>
   <string name="tethering_manage">系統網路共用管理…</string>
   <string name="tethering_manage_offload_enabled">若 VPN 網路共用無法運作，請在「開發人員選項」中關閉「網路共用硬體加速」。</string>
   <string name="tethering_manage_usb">USB 網路共用</string>

--- a/mobile/src/main/res/values-zh-rTW/strings.xml
+++ b/mobile/src/main/res/values-zh-rTW/strings.xml
@@ -54,7 +54,7 @@
   <string name="tethering_gateway">閘道共用</string>
   <string name="tethering_gateway_empty">沒有可用介面（需要一個已啟用且帶 IPv4 位址的介面）。</string>
   <string name="tethering_gateway_ra_preference">IPv6 NAT66 / RA 優先順序</string>
-  <string name="tethering_gateway_ra_follow_global">依照全域設定</string>
+  <string name="tethering_gateway_ra_follow_global">依照全域 IPv6 模式</string>
   <string name="tethering_gateway_ra_high">高</string>
   <string name="tethering_gateway_ra_medium">中</string>
   <string name="tethering_gateway_ra_low">低</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -58,9 +58,7 @@
 
     <string name="tethering_watch_reconnect">Watch for reconnect</string>
 
-    <string name="tethering_gateway">Gateway (single-arm router)</string>
-    <string name="tethering_gateway_summary">Route an existing LAN this device joined as a client into the VPN.
-        On other devices, set their gateway (and DNS) to this device’s IP on the chosen interface.</string>
+    <string name="tethering_gateway">Gateway sharing</string>
     <string name="tethering_gateway_empty">No eligible interface (needs an up interface with an IPv4 address).</string>
 
     <string name="tethering_manage">Manage system tethering…</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -61,7 +61,7 @@
     <string name="tethering_gateway">Gateway sharing</string>
     <string name="tethering_gateway_empty">No eligible interface (needs an up interface with an IPv4 address).</string>
     <string name="tethering_gateway_ra_preference">IPv6 NAT66 / RA preference</string>
-    <string name="tethering_gateway_ra_disabled">Disabled</string>
+    <string name="tethering_gateway_ra_follow_global">Follow global setting</string>
     <string name="tethering_gateway_ra_high">High</string>
     <string name="tethering_gateway_ra_medium">Medium</string>
     <string name="tethering_gateway_ra_low">Low</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -61,7 +61,7 @@
     <string name="tethering_gateway">Gateway sharing</string>
     <string name="tethering_gateway_empty">No eligible interface (needs an up interface with an IPv4 address).</string>
     <string name="tethering_gateway_ra_preference">IPv6 NAT66 / RA preference</string>
-    <string name="tethering_gateway_ra_follow_global">Follow global setting</string>
+    <string name="tethering_gateway_ra_follow_global">Follow global IPv6 mode</string>
     <string name="tethering_gateway_ra_high">High</string>
     <string name="tethering_gateway_ra_medium">Medium</string>
     <string name="tethering_gateway_ra_low">Low</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -60,6 +60,11 @@
 
     <string name="tethering_gateway">Gateway sharing</string>
     <string name="tethering_gateway_empty">No eligible interface (needs an up interface with an IPv4 address).</string>
+    <string name="tethering_gateway_ra_preference">IPv6 NAT66 / RA preference</string>
+    <string name="tethering_gateway_ra_disabled">Disabled</string>
+    <string name="tethering_gateway_ra_high">High</string>
+    <string name="tethering_gateway_ra_medium">Medium</string>
+    <string name="tethering_gateway_ra_low">Low</string>
 
     <string name="tethering_manage">Manage system tethering…</string>
     <string name="tethering_manage_offload_enabled">Please disable Tethering hardware acceleration in Developer options

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -58,6 +58,11 @@
 
     <string name="tethering_watch_reconnect">Watch for reconnect</string>
 
+    <string name="tethering_gateway">Gateway (single-arm router)</string>
+    <string name="tethering_gateway_summary">Route an existing LAN this device joined as a client into the VPN.
+        On other devices, set their gateway (and DNS) to this device’s IP on the chosen interface.</string>
+    <string name="tethering_gateway_empty">No eligible interface (needs an up interface with an IPv4 address).</string>
+
     <string name="tethering_manage">Manage system tethering…</string>
     <string name="tethering_manage_offload_enabled">Please disable Tethering hardware acceleration in Developer options
         if VPN tethering does not work.</string>

--- a/mobile/src/main/rust/vpnhotspotd/src/nat66/ra.rs
+++ b/mobile/src/main/rust/vpnhotspotd/src/nat66/ra.rs
@@ -526,7 +526,7 @@ async fn send_ra(
     let fd = create_send_socket(&config.downstream, config.reply_mark, router)?;
     let destination =
         target.unwrap_or_else(|| SocketAddrV6::new(ALL_NODES, 0, 0, router.interface_index));
-    let packet = make_current_ra_packet(ipv6_nat.gateway, mtu);
+    let packet = make_current_ra_packet(ipv6_nat.gateway, mtu, ipv6_nat.ra_preference);
     send_packet_to(&fd, &packet, SockAddr::from(destination)).await
 }
 

--- a/mobile/src/main/rust/vpnhotspotd/src/routing.rs
+++ b/mobile/src/main/rust/vpnhotspotd/src/routing.rs
@@ -37,7 +37,7 @@ pub(crate) use static_addresses::replace_static_addresses;
 const RULE_PRIORITY_DAEMON_BASE: u32 = 20600;
 // Gateway (single-arm router) return path: VPN replies arrive on the upstream and must look up the
 // main table to reach the downstream client subnet. Sits between the daemon and upstream priorities.
-const RULE_PRIORITY_GATEWAY_RETURN_BASE: u32 = 20650;
+const RULE_PRIORITY_GATEWAY_RETURN_BASE: u32 = 20500;
 const RULE_PRIORITY_UPSTREAM_BASE: u32 = 20700;
 const RULE_PRIORITY_UPSTREAM_FALLBACK_BASE: u32 = 20800;
 const RULE_PRIORITY_UPSTREAM_DISABLE_SYSTEM_BASE: u32 = 20900;

--- a/mobile/src/main/rust/vpnhotspotd/src/routing.rs
+++ b/mobile/src/main/rust/vpnhotspotd/src/routing.rs
@@ -35,6 +35,9 @@ pub(crate) use static_addresses::replace_static_addresses;
 // https://android.googlesource.com/platform/system/netd/+/android-10.0.0_r1/server/RouteController.cpp#65
 // https://android.googlesource.com/platform/system/netd/+/e11b8688b1f99292ade06f89f957c1f7e76ceae9/server/RouteController.h#51
 const RULE_PRIORITY_DAEMON_BASE: u32 = 20600;
+// Gateway (single-arm router) return path: VPN replies arrive on the upstream and must look up the
+// main table to reach the downstream client subnet. Sits between the daemon and upstream priorities.
+const RULE_PRIORITY_GATEWAY_RETURN_BASE: u32 = 20650;
 const RULE_PRIORITY_UPSTREAM_BASE: u32 = 20700;
 const RULE_PRIORITY_UPSTREAM_FALLBACK_BASE: u32 = 20800;
 const RULE_PRIORITY_UPSTREAM_DISABLE_SYSTEM_BASE: u32 = 20900;
@@ -280,6 +283,12 @@ pub(crate) async fn clean(
         handle,
         IpFamily::Ipv4,
         rule_priority(RULE_PRIORITY_UPSTREAM_DISABLE_SYSTEM_BASE),
+    )
+    .await?;
+    delete_rule_repeated(
+        handle,
+        IpFamily::Ipv4,
+        rule_priority(RULE_PRIORITY_GATEWAY_RETURN_BASE),
     )
     .await?;
     clean_ip(handle, command).await?;

--- a/mobile/src/main/rust/vpnhotspotd/src/routing/desired.rs
+++ b/mobile/src/main/rust/vpnhotspotd/src/routing/desired.rs
@@ -9,7 +9,7 @@ use vpnhotspotd::shared::downstream::DownstreamIpv4;
 use vpnhotspotd::shared::model::{
     mac_string, ClientDnsPorts, ClientIpv6NatPorts, Ipv6NatConfig, Ipv6NatPorts, SessionConfig,
     SessionPorts, UpstreamConfig, UpstreamRole, DAEMON_INTERCEPT_FWMARK_MASK,
-    DAEMON_INTERCEPT_FWMARK_VALUE, DAEMON_TABLE, LOCAL_NETWORK_TABLE,
+    DAEMON_INTERCEPT_FWMARK_VALUE, DAEMON_TABLE, LOCAL_NETWORK_TABLE, MAIN_TABLE,
 };
 use vpnhotspotd::shared::proto::daemon::MasqueradeMode;
 
@@ -22,8 +22,8 @@ use super::netlink_commands::{
 };
 use super::{
     push_unique, rule_priority, RoutingMutation, Runtime, RULE_PRIORITY_DAEMON_BASE,
-    RULE_PRIORITY_UPSTREAM_BASE, RULE_PRIORITY_UPSTREAM_DISABLE_SYSTEM_BASE,
-    RULE_PRIORITY_UPSTREAM_FALLBACK_BASE,
+    RULE_PRIORITY_GATEWAY_RETURN_BASE, RULE_PRIORITY_UPSTREAM_BASE,
+    RULE_PRIORITY_UPSTREAM_DISABLE_SYSTEM_BASE, RULE_PRIORITY_UPSTREAM_FALLBACK_BASE,
 };
 
 impl Runtime {
@@ -143,6 +143,26 @@ impl Runtime {
                         ip_protocol: None,
                     })),
                 );
+                // Gateway return path: unlike a tether downstream, a single-arm router interface is not
+                // registered in netd's local_network table, so VPN replies arriving on the upstream have
+                // no route back to the client subnet. Route upstream-ingress traffic via the main table,
+                // which carries the kernel connected route for the downstream subnet. Skip upstreams that
+                // are the downstream itself (the fallback can equal it) to avoid hijacking forward traffic.
+                if config.gateway && ifname.as_str() != config.downstream {
+                    push_unique(
+                        &mut mutations,
+                        RoutingMutation::Ip(IpCommand::Rule(IpRuleCommand {
+                            operation: IpOperation::Replace,
+                            family: IpFamily::Ipv4,
+                            iif: ifname.clone(),
+                            priority: rule_priority(RULE_PRIORITY_GATEWAY_RETURN_BASE),
+                            action: RuleAction::Lookup,
+                            table: MAIN_TABLE,
+                            fwmark: None,
+                            ip_protocol: None,
+                        })),
+                    );
+                }
                 match config.masquerade {
                     MasqueradeMode::None => {}
                     MasqueradeMode::Simple => push_unique(

--- a/mobile/src/main/rust/vpnhotspotd/src/shared/ipsec.rs
+++ b/mobile/src/main/rust/vpnhotspotd/src/shared/ipsec.rs
@@ -351,6 +351,7 @@ mUserResourceTracker:
                 .collect(),
             clients: Vec::new(),
             ipv6_nat: None,
+            gateway: false,
         }
     }
 }

--- a/mobile/src/main/rust/vpnhotspotd/src/shared/model.rs
+++ b/mobile/src/main/rust/vpnhotspotd/src/shared/model.rs
@@ -37,6 +37,9 @@ pub const DAEMON_ICMP_NFQUEUE_NUM: u16 = 30_000;
 /// that range while avoiding kernel-reserved tables and AOSP's fixed 97..99 tables.
 pub const DAEMON_TABLE: u32 = 900;
 pub const LOCAL_NETWORK_TABLE: u32 = 99;
+/// Kernel's main routing table (RT_TABLE_MAIN). Holds the kernel-installed connected route for
+/// every interface's own subnet, so a gateway downstream's client subnet is reachable here.
+pub const MAIN_TABLE: u32 = 254;
 
 pub fn kernel_release_supports_fra_ip_proto(release: &str) -> Option<bool> {
     let (major, rest) = release.split_once('.')?;
@@ -65,6 +68,8 @@ pub struct SessionConfig {
     pub fallback_upstream_interfaces: Vec<String>,
     pub clients: Vec<ClientConfig>,
     pub ipv6_nat: Option<Ipv6NatConfig>,
+    /// Single-arm router downstream: add a return-path rule so VPN replies reach the client subnet.
+    pub gateway: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -362,6 +367,7 @@ mod tests {
             fallback_upstream_interfaces: Vec::new(),
             clients: Vec::new(),
             ipv6_nat: None,
+            gateway: false,
         }
     }
 

--- a/mobile/src/main/rust/vpnhotspotd/src/shared/model.rs
+++ b/mobile/src/main/rust/vpnhotspotd/src/shared/model.rs
@@ -101,9 +101,17 @@ pub struct ClientConfig {
     pub ipv4: Vec<Ipv4Addr>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RaPreference {
+    High,
+    Medium,
+    Low,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Ipv6NatConfig {
     pub gateway: Ipv6Inet,
+    pub ra_preference: RaPreference,
 }
 
 #[derive(Clone)]
@@ -385,6 +393,7 @@ mod tests {
     fn ipv6_nat_config() -> Ipv6NatConfig {
         Ipv6NatConfig {
             gateway: Ipv6Inet::new("fd00::1".parse().unwrap(), 64).unwrap(),
+            ra_preference: RaPreference::Medium,
         }
     }
 }

--- a/mobile/src/main/rust/vpnhotspotd/src/shared/protocol.rs
+++ b/mobile/src/main/rust/vpnhotspotd/src/shared/protocol.rs
@@ -10,10 +10,10 @@ use prost::Message;
 
 use crate::shared::ipsec::IpSecForwardPolicyTarget;
 use crate::shared::model::{
-    ipv6_nat_gateway, ipv6_nat_prefix, ClientConfig, Ipv6NatConfig, SessionConfig,
+    ipv6_nat_gateway, ipv6_nat_prefix, ClientConfig, Ipv6NatConfig, RaPreference, SessionConfig,
     DAEMON_REPLY_MARK,
 };
-use crate::shared::proto::daemon::{self, DaemonErrorReport, MasqueradeMode};
+use crate::shared::proto::daemon::{self, DaemonErrorReport, MasqueradeMode, RaPreference as ProtoRaPreference};
 
 pub(crate) const MAX_ERROR_DETAILS: usize = 32;
 const MAX_ERROR_FIELD_BYTES: usize = 4096;
@@ -285,7 +285,12 @@ pub fn read_session_config(config: daemon::SessionConfig) -> io::Result<SessionC
     let ipv6_nat = if let Some(ipv6_nat) = config.ipv6_nat {
         let prefix = ipv6_nat_prefix(&ipv6_nat.prefix_seed, &downstream);
         let gateway = ipv6_nat_gateway(prefix);
-        Some(Ipv6NatConfig { gateway })
+        let ra_preference = match ProtoRaPreference::try_from(ipv6_nat.ra_preference) {
+            Ok(ProtoRaPreference::High) => RaPreference::High,
+            Ok(ProtoRaPreference::Low) => RaPreference::Low,
+            _ => RaPreference::Medium,
+        };
+        Some(Ipv6NatConfig { gateway, ra_preference })
     } else {
         None
     };

--- a/mobile/src/main/rust/vpnhotspotd/src/shared/protocol.rs
+++ b/mobile/src/main/rust/vpnhotspotd/src/shared/protocol.rs
@@ -303,6 +303,7 @@ pub fn read_session_config(config: daemon::SessionConfig) -> io::Result<SessionC
         fallback_upstream_interfaces: config.fallback_upstream_interfaces,
         clients,
         ipv6_nat,
+        gateway: config.gateway,
     })
 }
 

--- a/mobile/src/main/rust/vpnhotspotd/src/shared/ra_wire.rs
+++ b/mobile/src/main/rust/vpnhotspotd/src/shared/ra_wire.rs
@@ -7,11 +7,13 @@ use etherparse::icmpv6::{
 };
 use etherparse::{Icmpv6Header, Icmpv6Type};
 
+use crate::shared::model::RaPreference;
+
 // Recursive DNS Server option, RFC 8106 section 5.1.
 const RDNSS_OPTION_TYPE: NdpOptionType = NdpOptionType(25);
 const RDNSS_OPTION_LENGTH_UNITS: u8 = 3;
 
-pub fn make_current_ra_packet(gateway: Ipv6Inet, mtu: u32) -> Vec<u8> {
+pub fn make_current_ra_packet(gateway: Ipv6Inet, mtu: u32, preference: RaPreference) -> Vec<u8> {
     RaAdvertisement {
         dns_server: gateway.address(),
         advertised_prefix: gateway.network(),
@@ -20,6 +22,7 @@ pub fn make_current_ra_packet(gateway: Ipv6Inet, mtu: u32) -> Vec<u8> {
         valid_lifetime: 3600,
         preferred_lifetime: 1800,
         rdnss_lifetime: 600,
+        ra_preference: preference,
     }
     .encode()
 }
@@ -33,6 +36,7 @@ pub fn make_zero_lifetime_ra_packet(prefix: Ipv6Inet, mtu: u32, keep_router: boo
         valid_lifetime: 0,
         preferred_lifetime: 0,
         rdnss_lifetime: 0,
+        ra_preference: RaPreference::Medium,
     }
     .encode()
 }
@@ -49,6 +53,7 @@ struct RaAdvertisement {
     valid_lifetime: u32,
     preferred_lifetime: u32,
     rdnss_lifetime: u32,
+    ra_preference: RaPreference,
 }
 
 impl RaAdvertisement {
@@ -63,6 +68,13 @@ impl RaAdvertisement {
             }))
             .to_bytes(),
         );
+        // RFC 4191: Default Router Preference in bits 4-3 of the flags byte (packet[5])
+        let prf_bits = match self.ra_preference {
+            RaPreference::High => 0x08,
+            RaPreference::Medium => 0x00,
+            RaPreference::Low => 0x18,
+        };
+        packet[5] |= prf_bits;
         packet.extend_from_slice(
             &RouterAdvertisementPayload {
                 reachable_time: 0,
@@ -122,6 +134,7 @@ mod tests {
             valid_lifetime: 0,
             preferred_lifetime: 0,
             rdnss_lifetime: 0,
+            ra_preference: RaPreference::Medium,
         }
         .encode();
         assert_eq!(&packet[20..24], &0u32.to_be_bytes());
@@ -132,7 +145,7 @@ mod tests {
     #[test]
     fn current_ra_masks_gateway_to_advertised_prefix() {
         let gateway = Ipv6Inet::new("fd47:6b7c:2186:b452::1".parse().unwrap(), 64).unwrap();
-        let packet = make_current_ra_packet(gateway, 1500);
+        let packet = make_current_ra_packet(gateway, 1500, RaPreference::Medium);
         assert_eq!(
             &packet[32..48],
             &"fd47:6b7c:2186:b452::"
@@ -141,6 +154,27 @@ mod tests {
                 .octets()
         );
         assert_eq!(&packet[64..80], &gateway.address().octets());
+    }
+
+    #[test]
+    fn ra_preference_high_sets_correct_bits() {
+        let gateway = Ipv6Inet::new("fd47:6b7c:2186:b452::1".parse().unwrap(), 64).unwrap();
+        let packet = make_current_ra_packet(gateway, 1500, RaPreference::High);
+        assert_eq!(packet[5] & 0x18, 0x08);
+    }
+
+    #[test]
+    fn ra_preference_low_sets_correct_bits() {
+        let gateway = Ipv6Inet::new("fd47:6b7c:2186:b452::1".parse().unwrap(), 64).unwrap();
+        let packet = make_current_ra_packet(gateway, 1500, RaPreference::Low);
+        assert_eq!(packet[5] & 0x18, 0x18);
+    }
+
+    #[test]
+    fn ra_preference_medium_clears_preference_bits() {
+        let gateway = Ipv6Inet::new("fd47:6b7c:2186:b452::1".parse().unwrap(), 64).unwrap();
+        let packet = make_current_ra_packet(gateway, 1500, RaPreference::Medium);
+        assert_eq!(packet[5] & 0x18, 0x00);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a **Gateway sharing** mode that shares this device's VPN with other hosts on a LAN it has joined as an ordinary client, by acting as a single-arm router (router-on-a-stick) instead of running a hotspot. Other devices set this device as their gateway/DNS and their traffic is routed into the VPN. Implements the request in #518.

Unlike the existing tether / local-only / repeater downstreams (interfaces Android itself creates), a gateway downstream is a physical interface the device joined as a client (e.g. `wlan0`), so it is never part of the system tethering state.

## How it works

It reuses the existing downstream routing pipeline (`Routing` / `RoutingManager` / the Rust daemon). The behavior specific to gateway mode is small:

- **Gateway downstream lifecycle** (`TetheringService`): a downstream flavor that starts immediately on a user-chosen interface, is not gated on or torn down by `TetherStates`, and enables `ip_forward` (the tethering stack does not manage this interface). Reuses the existing multi-downstream lifecycle, foreground service, boot persistence, binder, and neighbour/client stats.
- **Return-path rule** (daemon): VPN replies arrive on the upstream and are routed by netd's `iif <upstream> lookup local_network` rule, but a gateway downstream's subnet is never registered in `local_network` (netd only does that for real tethers), so replies were unreachable and clients timed out. The daemon now adds `iif <upstream> lookup main`, skipping any upstream that equals the downstream so it cannot hijack forward traffic. A new `gateway` flag on `SessionConfig` requests it. Catalogued in `docs/vpnhotspotd/routing.md`.
- **UI**: a "Gateway sharing" group on the tethering screen lists eligible physical interfaces (up, non-loopback, non-P2P, has IPv4) with a per-interface toggle. Usage is documented in README; the row is kept terse to match the other entries.

Upstream VPN selection, NAT/masquerade, the VPN-down `unreachable` guard, per-client DNS redirection (resolved over the VPN via `android_res_nsend`), and reversible cleanup are all inherited unchanged.

## Reversibility

No app-owned persistent state. The return rule is removed on stop/replace and by `Clean` (deleted by its priority, like the other policy rules), so force-stop / process death / reboot stay recoverable.

## Test plan

Built and verified on a rooted **Redmi K30 5G, Android 10 (API 29), Magisk**:

- [x] `./gradlew :mobile:compileDebugKotlin` and `:mobile:assembleDebug` pass.
- [x] Daemon: `cargo fmt --check`, `cargo ndk … check`, `clippy -D warnings`, `check --tests` all clean.
- [x] Device joined home Wi-Fi as a client (`wlan0`) with a separate VPN (`tun0`) connected; enabling Gateway sharing on `wlan0` made the daemon install the expected rules (`iif wlan0 lookup <vpn>`, the `unreachable` guard, and the new `iif tun0 lookup main`).
- [x] A second LAN device with its gateway + DNS pointed at this device reached the internet through the VPN.
- [x] Toggling the interface off removes all gateway rules; toggling on restores them.

## Notes

- This is a niche, more-technical-to-set-up alternative to the hotspot (as noted in #518); it reuses the existing machinery, so the new surface is small.
- IPv6 follows the existing per-session `ipv6Mode` setting (blocked by default), same as the other downstreams.
- `send_redirects` / `rp_filter` were intentionally **not** touched: forwarded traffic egresses the VPN `tun`, not the ingress interface, so the kernel emits no ICMP redirects and reverse-path stays symmetric (matches known working shell setups).
- Translations: the new strings ship with English (default), Simplified and Traditional Chinese (`zh-rCN`, `zh-rHK`, `zh-rTW`), and Japanese (`ja`); all other locales fall back to the default English and are left to the project's usual translation flow.
